### PR TITLE
Fix ssh key file permissions

### DIFF
--- a/deploy-gh-pages.sh
+++ b/deploy-gh-pages.sh
@@ -11,5 +11,7 @@ git config user.name "qTox bot"
 git config user.email "qTox@users.noreply.github.com"
 git add .
 git commit -m "Deploy to GH pages."
+touch /tmp/access_key
+chmod 600 /tmp/access_key
 echo "$access_key" > /tmp/access_key
-GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com:qTox/qtox.github.io.git" master:master &> /dev/null
+GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com:qTox/qtox.github.io.git" master:master


### PR DESCRIPTION
ssh rejects key files that have world-readable permissions.

Also don't pipe ssh push to dev null so that we can see errors